### PR TITLE
Implement async exercise

### DIFF
--- a/async/index.js
+++ b/async/index.js
@@ -33,4 +33,23 @@ module.exports = {
       thunks.forEach(processThunk);
     };
   },
+
+  race(thunks) {
+    return function (finalCallback) {
+      let completed = false;
+
+      function processThunk(thunk) {
+        thunk((error, data) => {
+          if (completed) {
+            return;
+          }
+
+          completed = true;
+          finalCallback(error, data);
+        });
+      }
+
+      thunks.forEach(processThunk);
+    };
+  },
 };

--- a/async/index.js
+++ b/async/index.js
@@ -1,9 +1,16 @@
 module.exports = {
   sequence(thunks) {
     return function (finalCallback) {
-      thunks[0]((e, data) => {
-        thunks[1](finalCallback, data);
-      });
+      function processThunk(index, data = null) {
+        const thunk = thunks[index];
+        const nextIndex = index + 1;
+        const isLastThunk = nextIndex === thunks.length;
+        const callback = isLastThunk ? finalCallback : (e, nextData) => processThunk(nextIndex, nextData);
+
+        thunk(callback, data);
+      }
+
+      processThunk(0);
     };
   },
 };

--- a/async/index.js
+++ b/async/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  sequence(thunks) {
+    return function (finalCallback) {
+      thunks[0]((e, data) => {
+        thunks[1](finalCallback, data);
+      });
+    };
+  },
+};

--- a/async/index.js
+++ b/async/index.js
@@ -13,4 +13,24 @@ module.exports = {
       processThunk(0);
     };
   },
+
+  parallel(thunks) {
+    return function (finalCallback) {
+      const data = Array(thunks.length);
+      let completedThunks = 0;
+
+      function processThunk(thunk, index) {
+        thunk((error, thunkData) => {
+          data[index] = thunkData;
+          completedThunks++;
+
+          if (completedThunks === thunks.length) {
+            finalCallback(null, data);
+          }
+        });
+      }
+
+      thunks.forEach(processThunk);
+    };
+  },
 };

--- a/async/test.js
+++ b/async/test.js
@@ -52,6 +52,18 @@ describe('async', function() {
         });
       }, 100)
     });
+
+    it('takes an arbitrary number of thunks', (done) => {
+      const one = cb => setTimeout(cb.bind(null, null, 'one'), 10);
+      const two = (cb, data) => setTimeout(cb.bind(null, null, data + ' two'), 10);
+      const three = (cb, data) => setTimeout(cb.bind(null, null, data + ' three'), 10);
+      const four = (cb, data) => setTimeout(cb.bind(null, null, data + ' four'), 10);
+
+      async.sequence([one, two, three, four])(function(err, data) {
+        assert.equal(data, 'one two three four');
+        done();
+      });
+    });
   });
 
   describe('has a parallel method that', function() {


### PR DESCRIPTION
This PR implements the `async` functions as described by async/tests.js. Again, I kept commits small (one per function in this case). Note that I added an additional test for `sequence` to encourage a more complete implementation for `sequence` than my original naive implementation.